### PR TITLE
Fix text cursor position after wrong command

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -47,6 +47,7 @@ public class CommandBox extends UiPart<Region> {
             commandExecutor.execute(commandText);
         } catch (CommandException | ParseException e) {
             commandTextField.setText(commandText);
+            commandTextField.positionCaret(commandText.length());
             setStyleToIndicateCommandFailure();
         }
     }


### PR DESCRIPTION
Cursor remains at the end after error command

Fixes #144 