### PR TITLE
Closing the 'Clear' warning window changes 'Closed warning window' to 'Clear command cancelled'

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -231,7 +231,7 @@ public class MainWindow extends UiPart<Stage> {
                 isProcessingClearConfirmation = false;
 
                 if (isManualCloseClearConfirmation) {
-                    resultDisplay.setFeedbackToUser("Closed warning window.");
+                    resultDisplay.setFeedbackToUser("Clear command cancelled.");
                 }
             });
         }


### PR DESCRIPTION
Fix #217: Clicking 'X' on warning window changes 'Closed warning window' to 'Clear command cancelled'